### PR TITLE
Set bot presence in client constructor

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -11,7 +11,7 @@ from tex2png import *
 import asyncio
 
 
-client = discord.Client()
+client = discord.Client(status = discord.Status.idle, activity = discord.Game("TexRender"))
 
 async def handle_tex_message(message):
     text = message.content[5:] #Remove the '$tex ' at beginning
@@ -38,7 +38,6 @@ async def handle_tex_message(message):
 @client.event
 async def on_ready():
     print('Logged in as {0.user}'.format(client))
-    await client.change_presence(status = discord.Status.idle, activity = discord.Game("TexRender"))
 
 @client.event
 async def on_message(message):


### PR DESCRIPTION
Discord has a high chance to completely disconnect during the READY or GUILD_CREATE events (1006 close code) and there is nothing to do to prevent it. 
As noted in the docs, `on_ready` is also triggered multiple times, not just once.
Therefore it is highly inadvisable to change presence in `on_ready`
This pr fixes that and puts `activity=` in client constructor instead.